### PR TITLE
chore: update docker image version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ docker run --rm -it \
 	-e SQ_ORG="accuknox" /* needed for sonarcloud.io */ \
 	-e REPORT_PATH=/app/data/ \
 	-v $PWD:/app/data/ \
-	accuknox/sastjob:latest
+	accuknox/sastjob:1.0.2
 ```
 
 This will create a bunch of SQ-*.json files, one for every project/component found.


### PR DESCRIPTION
The Docker image with the recent description fixes is published as version 1.0.2. Readme has been updated.
![image](https://github.com/user-attachments/assets/f84b2d76-08f8-402f-85fe-f55508f4f0bc)
