### PR TITLE
update(Makefile): push 2 tags: latest and the release tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 REPO=accuknox
 IMGNAME=sastjob
 IMGTAG?=latest
-IMG=${REPO}/${IMGNAME}:${IMGTAG}
 
 docker-buildx:
-	docker buildx build -f ./Dockerfile . --platform linux/arm64,linux/amd64 -t ${IMG} --push
+	docker buildx build -f ./Dockerfile . --platform linux/arm64,linux/amd64 \
+	-t ${REPO}/${IMGNAME}:${IMGTAG} \
+	-t ${REPO}/${IMGNAME}:latest \
+	--push


### PR DESCRIPTION
Pushing just the release tag makes it hard to maintain CI flows where we have to keep updating the recent version to stay up to date.
It's necessary and good practice to have both latest and specific release tag.